### PR TITLE
feat: 폼 관련 컴포넌트 추가, tailwind config 수정

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -71,6 +71,7 @@ module.exports = {
                 ignores: ['default', 'index', 'Header', 'login'],
             },
         ],
+        'vue/no-multiple-template-root': 'off',
     },
     overrides: [
         {

--- a/components/GoalForm.vue
+++ b/components/GoalForm.vue
@@ -26,30 +26,30 @@ const goalPrice = computed(() => {
 </script>
 
 <template>
-    <div class="flex flex-col px-4 py-5 bg-bg-gray">
+    <div class="flex flex-col px-4 py-5 bg-gray10">
         <basic-input :value="goalTitle" :variant="'goalTitle'" />
 
         <div class="mt-8 flex flex-row gap-7">
             <div class="w-1/2">
                 <span class="text-sm"> 시간을 설정해주세요. </span>
                 <div class="flex flex-row items-center mt-[10px]">
-                    <basic-input />
+                    <basic-input :placeholder="'시간'" class="text-center" />
                     <span class="px-2"> : </span>
-                    <basic-input />
+                    <basic-input :placeholder="'분'" class="text-center" />
                 </div>
             </div>
             <div class="w-1/2">
                 <span class="text-sm"> 중요도를 선택해주세요. </span>
                 <div
-                    class="grid grid-cols-3 divide-x divide-light-purple text-purple font-bold bg-white rounded border border-light-purple mt-[10px]"
+                    class="grid grid-cols-3 divide-x divide-purple12 text-purple7 font-bold bg-white rounded border border-purple12 mt-[10px]"
                 >
                     <div
                         v-for="weight in weightLevels"
                         :key="weight"
                         class="p-4 text-center"
                         :class="{
-                            'border-middle-purple': isSelectedWeight(weight),
-                            'bg-light-purple': isSelectedWeight(weight),
+                            'border-purple10': isSelectedWeight(weight),
+                            'bg-purple12': isSelectedWeight(weight),
                         }"
                         @click="curWeight = WEIGHT_LEVEL[weight]"
                     >
@@ -62,13 +62,13 @@ const goalPrice = computed(() => {
         <span class="font-bold text-sm pt-8 pb-[10px]">
             설정하신 시간을 자동으로 계산해봤어요.
         </span>
-        <div class="p-4 rounded font-bold text-xl text-purple bg-white">
+        <div class="p-4 rounded font-bold text-xl text-purple7 bg-white">
             {{ goalPrice }}원
         </div>
 
         <div class="flex flex-row gap-2 mt-4">
-            <basic-button>취소하기</basic-button>
-            <basic-button>생성하기</basic-button>
+            <basic-button :theme="'ghost'">취소하기</basic-button>
+            <basic-button :theme="'primary'">생성하기</basic-button>
         </div>
     </div>
 </template>

--- a/components/GoalForm.vue
+++ b/components/GoalForm.vue
@@ -1,5 +1,74 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import {ref, computed} from 'vue';
+
+import {WEIGHT_LEVEL} from '~/types';
+import type {WeightLevel} from '~/types';
+
+const hourPrice = ref(1000); // TODO
+
+const goalTitle = ref('');
+
+const curWeight = ref(WEIGHT_LEVEL['0']);
+const weightLevels = Object.keys(WEIGHT_LEVEL);
+const isSelectedWeight = (weight: WeightLevel) => {
+    return curWeight.value === WEIGHT_LEVEL[weight];
+};
+
+const hour = ref(0);
+const minute = ref(0);
+
+const goalPrice = computed(() => {
+    if (hour.value && minute.value) {
+        return hourPrice.value * (hour.value + Number(minute.value / 60));
+    }
+    return 0;
+});
+</script>
 
 <template>
-    <div>목표 생성</div>
+    <div class="flex flex-col px-4 py-5 bg-bg-gray">
+        <basic-input :value="goalTitle" :variant="'goalTitle'" />
+
+        <div class="mt-8 flex flex-row gap-7">
+            <div class="w-1/2">
+                <span class="text-sm"> 시간을 설정해주세요. </span>
+                <div class="flex flex-row items-center mt-[10px]">
+                    <basic-input />
+                    <span class="px-2"> : </span>
+                    <basic-input />
+                </div>
+            </div>
+            <div class="w-1/2">
+                <span class="text-sm"> 중요도를 선택해주세요. </span>
+                <div
+                    class="grid grid-cols-3 divide-x divide-light-purple text-purple font-bold bg-white rounded border border-light-purple mt-[10px]"
+                >
+                    <div
+                        v-for="weight in weightLevels"
+                        :key="weight"
+                        class="p-4 text-center"
+                        :class="{
+                            'border-middle-purple': isSelectedWeight(weight),
+                            'bg-light-purple': isSelectedWeight(weight),
+                        }"
+                        @click="curWeight = WEIGHT_LEVEL[weight]"
+                    >
+                        {{ WEIGHT_LEVEL[weight] }}
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <span class="font-bold text-sm pt-8 pb-[10px]">
+            설정하신 시간을 자동으로 계산해봤어요.
+        </span>
+        <div class="p-4 rounded font-bold text-xl text-purple bg-white">
+            {{ goalPrice }}원
+        </div>
+
+        <div class="flex flex-row gap-2 mt-4">
+            <basic-button>취소하기</basic-button>
+            <basic-button>생성하기</basic-button>
+        </div>
+    </div>
 </template>

--- a/components/GoalForm.vue
+++ b/components/GoalForm.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts"></script>
+
+<template>
+    <div>목표 생성</div>
+</template>

--- a/components/RetrospectForm.vue
+++ b/components/RetrospectForm.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+import {ref} from 'vue';
+</script>
+
+<template>
+    <div class="flex flex-col">회고 작성</div>
+</template>

--- a/components/commons/BasicButton.vue
+++ b/components/commons/BasicButton.vue
@@ -1,10 +1,29 @@
 <script setup lang="ts">
+export interface Props {
+    theme?: string;
+}
+const props = withDefaults(defineProps<Props>(), {
+    theme: 'default',
+});
 const emit = defineEmits(['onClick']);
+
+const backgroundColor: Record<string, string> = {
+    default: 'bg-gray10',
+    primary: 'bg-purple7',
+    secondary: 'bg-purple13',
+    ghost: 'bg-white',
+};
+const textColor: Record<string, string> = {
+    default: 'text-black',
+    primary: 'text-white',
+    secondary: 'text-purple7',
+    ghost: 'text-purple7',
+};
 </script>
 
 <template>
     <button
-        class="bg-purple text-white p-1 rounded w-full h-12 disabled:bg-gray"
+        :class="`${backgroundColor[theme]} ${textColor[theme]} p-1 rounded w-full h-12 font-bold active:bg-purple4 active:text-white hover:bg-purple9 hover:text-white disabled:bg-gray50`"
         @click="emit('onClick')"
     >
         <slot />

--- a/components/commons/BasicInput.vue
+++ b/components/commons/BasicInput.vue
@@ -165,10 +165,10 @@ const onFocus = (event: FocusEvent): void => {
             v-bind="$attrs"
             :type="refinedVariant(variant)"
             :class="{
-                'border-gray': !isFocused,
-                'border-purple': isFocused,
+                'border-gray50': !isFocused,
+                'border-purple7': isFocused,
                 '!border-error': validationState === 'error',
-                'text-gray bg-[#E1E1E1] border-none': isDisabled,
+                'text-gray50 bg-gray20 border-none': isDisabled,
             }"
             class="border-[1px] rounded-[6px] w-[100%] p-[16px] focus:outline-none mb-0"
             :placeholder="placeholder ?? placeholders[variant]"
@@ -186,7 +186,7 @@ const onFocus = (event: FocusEvent): void => {
                 (variant === 'email' && validationState === 'error') ||
                 (variant === 'passwordConfirm' && validationState === 'error')
             "
-            class="mt-[10px] font-medium text-xs text-gray"
+            class="mt-[10px] font-medium text-xs text-gray50"
             :class="{
                 '!text-error': validationState === 'error',
             }"

--- a/components/commons/BasicInput.vue
+++ b/components/commons/BasicInput.vue
@@ -63,6 +63,7 @@ const inputTitle: Record<string, string> = {
     password: '비밀번호',
     passwordConfirm: '비밀번호 확인',
     nickname: '닉네임',
+    goalTitle: '목표명을 입력해주세요.',
 };
 
 const placeholders: Record<string, string> = {
@@ -70,6 +71,7 @@ const placeholders: Record<string, string> = {
     password: '비밀번호 입력',
     passwordConfirm: '비밀번호 확인',
     nickname: '닉네임 입력',
+    goalTitle: '오늘의 목표 입력',
 };
 
 const breadcumbText: Record<string, string> = {

--- a/components/commons/CreateFormButton.vue
+++ b/components/commons/CreateFormButton.vue
@@ -10,7 +10,7 @@ const AsyncForm = defineAsyncComponent(
     () => import(`~/components/${props.formType}.vue`),
 );
 
-const showButton = ref(true);
+const showButton = ref(false);
 
 const onClickButton = () => {
     emit('onClick');
@@ -20,7 +20,7 @@ const onClickButton = () => {
 
 <template>
     <template v-if="showButton">
-        <basic-button class="h-20" @onClick="onClickButton">
+        <basic-button :theme="'primary'" class="h-20" @onClick="onClickButton">
             <slot />
         </basic-button>
     </template>

--- a/components/commons/CreateFormButton.vue
+++ b/components/commons/CreateFormButton.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import {ref, defineAsyncComponent} from 'vue';
+
+const props = defineProps({
+    formType: String,
+});
+const emit = defineEmits(['onClick']);
+
+const AsyncForm = defineAsyncComponent(
+    () => import(`~/components/${props.formType}.vue`),
+);
+
+const showButton = ref(true);
+
+const onClickButton = () => {
+    emit('onClick');
+    showButton.value = false;
+};
+</script>
+
+<template>
+    <template v-if="showButton">
+        <button
+            class="bg-purple text-white p-1 rounded w-full h-20 disabled:bg-gray"
+            @click="onClickButton"
+        >
+            <slot />
+        </button>
+    </template>
+    <template v-else>
+        <AsyncForm />
+    </template>
+</template>

--- a/components/commons/CreateFormButton.vue
+++ b/components/commons/CreateFormButton.vue
@@ -20,12 +20,9 @@ const onClickButton = () => {
 
 <template>
     <template v-if="showButton">
-        <button
-            class="bg-purple text-white p-1 rounded w-full h-20 disabled:bg-gray"
-            @click="onClickButton"
-        >
+        <basic-button class="h-20" @onClick="onClickButton">
             <slot />
-        </button>
+        </basic-button>
     </template>
     <template v-else>
         <AsyncForm />

--- a/pages/find-password.vue
+++ b/pages/find-password.vue
@@ -60,7 +60,10 @@ export default defineComponent({
                 @input.self="test"
                 @blur="checkEmailFormat"
             />
-            <basic-button class="mt-[20px]" :disabled="!loginButtonActivated"
+            <basic-button
+                :theme="'primary'"
+                class="mt-[20px]"
+                :disabled="!loginButtonActivated"
                 >임시 비밀번호 발급받기</basic-button
             >
         </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -34,6 +34,7 @@ const onClickCreateGoal = () => {
                                 오늘의 목표를 세우기 전, 큰 목표부터 세워
                                 보세요.
                             </span>
+                            <!-- TODO: CreateFormButton -->
                             <basic-button class="h-20 rounded text-base">
                                 + 이번달 목표 생성하기
                             </basic-button>
@@ -51,6 +52,7 @@ const onClickCreateGoal = () => {
                             <span class="text-light-gray text-sm pb-4">
                                 목표 달성 시 해당 가치로 환산해 드려요.
                             </span>
+                            <!-- TODO: CreateFormButton -->
                             <basic-button class="h-20 rounded text-base">
                                 + 한 시간의 가치 설정하기
                             </basic-button>
@@ -63,12 +65,13 @@ const onClickCreateGoal = () => {
                         <nuxt-icon name="main/FlagIcon" class="my-auto mr-2" />
                         오늘은 어떤 목표를 세워볼까요?
                     </span>
-                    <basic-button
-                        class="h-20 rounded text-base"
+                    <create-form-button
+                        class="text-base"
+                        :formType="'GoalForm'"
                         @onClick="onClickCreateGoal"
                     >
                         + 첫 번째 목표 생성하기
-                    </basic-button>
+                    </create-form-button>
                     <span class="font-bold text-xl pb-2 pt-10 flex">
                         <nuxt-icon
                             name="main/HistoryIcon"
@@ -79,9 +82,12 @@ const onClickCreateGoal = () => {
                     <span class="text-light-gray text-sm pb-4">
                         하루를 마무리하며 기록해보세요.
                     </span>
-                    <basic-button class="h-20 rounded text-base">
+                    <create-form-button
+                        class="text-base"
+                        :formType="'RetrospectForm'"
+                    >
                         + 회고 작성하기
-                    </basic-button>
+                    </create-form-button>
                 </div>
             </div>
         </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -30,7 +30,7 @@ const onClickCreateGoal = () => {
                                 />
                                 이번 달 목표는 무엇인가요?
                             </span>
-                            <span class="text-light-gray text-sm pb-4">
+                            <span class="text-gray60 text-sm pb-4">
                                 오늘의 목표를 세우기 전, 큰 목표부터 세워
                                 보세요.
                             </span>
@@ -49,11 +49,14 @@ const onClickCreateGoal = () => {
                                 />
                                 한 시간의 가치를 설정해 주세요.
                             </span>
-                            <span class="text-light-gray text-sm pb-4">
+                            <span class="text-gray60 text-sm pb-4">
                                 목표 달성 시 해당 가치로 환산해 드려요.
                             </span>
                             <!-- TODO: CreateFormButton -->
-                            <basic-button class="h-20 rounded text-base">
+                            <basic-button
+                                :theme="'secondary'"
+                                class="h-20 rounded text-base"
+                            >
                                 + 한 시간의 가치 설정하기
                             </basic-button>
                         </div>
@@ -61,7 +64,7 @@ const onClickCreateGoal = () => {
                 </div>
 
                 <div class="w-2/3 flex flex-col shadow-md rounded px-8 py-9">
-                    <span class="font-bold text-xl pb-2 text-purple pb-4 flex">
+                    <span class="font-bold text-xl pb-2 text-purple7 pb-4 flex">
                         <nuxt-icon name="main/FlagIcon" class="my-auto mr-2" />
                         오늘은 어떤 목표를 세워볼까요?
                     </span>
@@ -79,7 +82,7 @@ const onClickCreateGoal = () => {
                         />
                         오늘은 어떤 하루였나요?
                     </span>
-                    <span class="text-light-gray text-sm pb-4">
+                    <span class="text-gray60 text-sm pb-4">
                         하루를 마무리하며 기록해보세요.
                     </span>
                     <create-form-button

--- a/pages/join.vue
+++ b/pages/join.vue
@@ -91,6 +91,7 @@ const onGetVerifyCode = (retry = false) => {
             />
             <basic-button
                 v-if="!isEmailCodeInputVisible"
+                :theme="'primary'"
                 class="mt-[16px] mb-[32px]"
                 :disabled="emailVerifyButtonStatus"
                 @onClick="getVerifyCode(userEmailInput)"
@@ -100,7 +101,7 @@ const onGetVerifyCode = (retry = false) => {
                 v-else
                 class="mt-4 mb-8 h-[176px] rounded bg-[#F0F0F0] p-6"
             >
-                <h3 class="text-sm mb-4 text-purple font-semibold">
+                <h3 class="text-sm mb-4 text-purple7 font-semibold">
                     이메일로 전송된 확인코드 6자리를 입력해 주세요.
                 </h3>
                 <div class="flex justify-between items-center">
@@ -112,9 +113,11 @@ const onGetVerifyCode = (retry = false) => {
                         @input.self="onInputVerifyCode"
                     />
                     <basic-button
+                        :theme="'primary'"
                         class="ml-2 w-[88px]"
                         @onClick="onGetVerifyCode"
-                        >인증하기</basic-button
+                    >
+                        인증하기</basic-button
                     >
                 </div>
                 <div class="text-xs text-gray mt-[10px]">
@@ -154,12 +157,15 @@ const onGetVerifyCode = (retry = false) => {
             <section class="flex justify-between my-[20px]">
                 이용약관 컴포넌트
             </section>
-            <basic-button class="mb-[32px]" :disabled="!isEmailVerified"
+            <basic-button
+                :theme="'primary'"
+                class="mb-[32px]"
+                :disabled="!isEmailVerified"
                 >회원가입하기</basic-button
             >
             <div class="flex justify-center font-medium text-sm text-gray">
                 이미 계정이 있으신가요?
-                <NuxtLink to="/login" class="ml-[10px] text-purple underline"
+                <NuxtLink to="/login" class="ml-[10px] text-purple7 underline"
                     >로그인하기</NuxtLink
                 >
             </div>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -68,7 +68,10 @@ export default defineComponent({
                 :required="true"
                 @input.self="testPassword"
             />
-            <basic-button class="mt-[20px]" :disabled="!loginButtonActivated"
+            <basic-button
+                :theme="'primary'"
+                class="mt-[20px]"
+                :disabled="!loginButtonActivated"
                 >로그인하기</basic-button
             >
             <section class="flex justify-between mt-[20px]">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,12 +11,15 @@ module.exports = {
     theme: {
         colors: {
             'purple': '#5D31FE',
+            'middle-purple': '#9A7EFF',
+            'light-purple': '#D9CEFF',
             'orange': '#FF5416',
             'green': '#DEF048',
             'black': '#222222',
             'white': '#FFFFFF',
             'gray': '#969696',
             'light-gray': '#787878',
+            'bg-gray': '#f0f0f0',
             'hr': '#C8C8C8',
             'error': '#E83459',
         },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,18 +10,35 @@ module.exports = {
     ],
     theme: {
         colors: {
-            'purple': '#5D31FE',
-            'middle-purple': '#9A7EFF',
-            'light-purple': '#D9CEFF',
-            'orange': '#FF5416',
-            'green': '#DEF048',
-            'black': '#222222',
-            'white': '#FFFFFF',
-            'gray': '#969696',
-            'light-gray': '#787878',
-            'bg-gray': '#f0f0f0',
-            'hr': '#C8C8C8',
-            'error': '#E83459',
+            purple1: '#09051A',
+            purple2: '#1C0F4D',
+            purple3: '#2F1980',
+            purple4: '#381E99',
+            purple5: '#4B27CC',
+            purple6: '#542CE5',
+            purple7: '#5D31FE', // (=primary-color.purple)
+            purple8: '#6A41FF',
+            purple9: '#7C58FF',
+            purple10: '#9A7EFF',
+            purple11: '#BAA7FF',
+            purple12: '#D9CEFF',
+            purple13: '#EDE8FF',
+
+            orange: '#FF5416',
+            green: '#DEF048',
+            black: '#222222',
+            white: '#FFFFFF',
+
+            gray80: '#3C3C3C',
+            gray70: '#5A5A5A',
+            gray60: '#787878',
+            gray50: '#969696',
+            gray40: '#AAAAAA',
+            gray30: '#C8C8C8',
+            gray20: '#E1E1E1',
+            gray10: '#F0F0F0',
+
+            error: '#E83459',
         },
         //spacing: default (https://tailwindcss.com/docs/customizing-spacing#default-spacing-scale)
         borderRadius: {

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,1 @@
+export * from './weight-level';

--- a/types/weight-level.ts
+++ b/types/weight-level.ts
@@ -1,0 +1,7 @@
+export const WEIGHT_LEVEL = {
+    0: 0.5,
+    1: 1,
+    2: 2,
+};
+
+export type WeightLevel = keyof typeof WEIGHT_LEVEL;


### PR DESCRIPTION
- `CreateFormButton`: `props`로 `formType`을 받아, 동적으로 Form을 생성할 수 있습니다. 
- `GoalForm`: 목표를 생성하는 폼입니다. 
- `tailwind.config`의 컬러값들을 디자인 시스템과 동일하게 수정하였습니다. 
   -  참고: https://www.notion.so/bside/TailwindCSS-7370fb7309a24b7caac86c41c8475ecb?pvs=4
- `BasicButton`에 `theme` 값을 추가하였습니다. 
   - 테마는 `default`, `primary`, `secondary`, `ghost`가 있으며 실제 렌더링 된 모습은 다음과 같습니다. 
   - `active`와  `hover` 상태일 때의 스타일을 공통적으로 적용됩니다. 

<img width="442" alt="image" src="https://user-images.githubusercontent.com/24283401/233785244-d02aad4a-4d6c-4617-83de-1ca932e4f79e.png">
<img width="110" alt="image" src="https://user-images.githubusercontent.com/24283401/233785259-aba8a300-4651-474e-9b78-bea8640c34e9.png">

