### PR TITLE
feat: refresh token 로직 추가, calendar 초안 작성

### DIFF
--- a/apis/auth.ts
+++ b/apis/auth.ts
@@ -18,3 +18,11 @@ export const findPasswordApi = async (email: string) => {
         },
     });
 };
+
+export const verifyRefreshToken = async (refreshToken: string) => {
+    return await fetch(`${baseURL}/api/tokens/refresh`, {
+        headers: {
+            Refresh: refreshToken,
+        },
+    });
+};

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "eslint-plugin-cypress": "^2.12.1",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-vue": "^9.10.0",
+        "jwt-decode": "^3.1.2",
         "pinia": "^2.0.33",
         "prettier": "^2.8.7",
         "typescript": "^5.0.2",

--- a/pages/reward.vue
+++ b/pages/reward.vue
@@ -28,9 +28,10 @@ const attrs = ref([
     },
 ]);
 
-const changeSelectedDate = (day: any) => {
-    console.log(day);
-    date.value = day.date;
+const onGetRewardInfoByDate = (selectedDate: any) => {
+    console.log(selectedDate);
+    console.log(selectedDate.id);
+    date.value = selectedDate.date;
 };
 </script>
 
@@ -45,17 +46,15 @@ const changeSelectedDate = (day: any) => {
     <div class="w-full flex justify-center mt-5 mb-11">
         <div class="max-w-[988px] flex-1 flex flex-row justify-center gap-5">
             <div class="w-4/6 flex shadow-md flex-col rounded px-8 py-9">
-                <Calendar
-                    v-model="date"
-                    :attributes="attrs"
-                    expanded
-                    @dayclick="changeSelectedDate"
-                >
-                    <!-- <template #day-content="{date}">
-                        <div class="custom-day-cell">
-
-                        </div>
-                    </template> -->
+                <Calendar v-model="date" :attributes="attrs" expanded>
+                    <!-- @dayclick="changeSelectedDate" -->
+                    <template #day-content="{day}">
+                        <span
+                            class="flex justify-center cursor-pointer"
+                            @click="onGetRewardInfoByDate(day)"
+                            >{{ day.day }}</span
+                        >
+                    </template>
                 </Calendar>
             </div>
             <div
@@ -78,26 +77,34 @@ const changeSelectedDate = (day: any) => {
 }
 
 /** 일요일 */
-.vc-weekday-1 {
+.vc-weekday-1,
+.weekday-1 {
     color: #ff5416;
 }
 
 /** 토요일 */
-.vc-weekday-7 {
+.vc-weekday-7,
+.weekday-7 {
     color: #9a7eff;
 }
 
 .vc-day {
     padding-bottom: 50px;
+    height: 118px;
+    width: 83px;
 }
 
 .vc-highlights {
-    /* border: 2px solid #5d31fe;
-    background-color: #ede8ff; */
+    border: 2px solid #5d31fe;
+    background-color: #ede8ff;
 }
 
 .vc-highlight.vc-highlight-bg-solid {
     /* display: none; */
+}
+
+.vc-highlight.vc-highlight-bg-outline {
+    display: none;
 }
 
 .vc-focus {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3794,6 +3794,11 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jwt-decode@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
+  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
+
 klona@^2.0.6:
   version "2.0.6"
   resolved "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz"


### PR DESCRIPTION
### Detail

- 앞서 회사에서 말한것 처럼, refreshToken 처리하는 로직은 useApi와 다르게 javascript `fetch` 사용.
- `useApi` 의 `useFetch` 보다 더 먼저 수행하게 처리하여 토큰을 항상 검사하도록 유지.

- 캘린더 초안 작업.

<img width="1245" alt="image" src="https://github.com/bsideproject/three-pick_front/assets/52649378/c767e1d9-7d1b-410f-b1d0-491a4aa871fe">
